### PR TITLE
Add markdown parsing for fund description and key criteria

### DIFF
--- a/app/models/fund.rb
+++ b/app/models/fund.rb
@@ -65,10 +65,31 @@ class Fund < ActiveRecord::Base
     tags.count.positive?
   end
 
+  def key_criteria_html
+    markdown(key_criteria)
+  end
+
+  def description_html
+    markdown(description)
+  end
+
   include FundJsonSetters
   include FundArraySetters
 
   private
+
+    def markdown(str)
+      options = { hard_wrap: true,
+                  space_after_headers: true, fenced_code_blocks: true,
+                  link_attributes: { target: '_blank' } }
+
+      extensions = { autolink: true, disable_indented_code_blocks: true }
+
+      renderer = Redcarpet::Render::HTML.new(options)
+      markdown = Redcarpet::Markdown.new(renderer, extensions)
+
+      markdown.render(str)
+    end
 
     def set_slug
       self[:slug] = "#{funder.slug}-#{name.parameterize}" if funder

--- a/app/views/enquiries/new.html.haml
+++ b/app/views/enquiries/new.html.haml
@@ -39,6 +39,6 @@
 
       .uk-panel
         %h4.uk-text-bold Key criteria
-        = raw(@fund.key_criteria)
+        = raw(@fund.key_criteria_html)
 
         = link_to "Apply to #{@fund.name}", apply_proposal_fund_path(@proposal, @fund), method: :post, target: '_blank', 'data-uk-tooltip': "{pos:'top'}", title: 'A new page will be opened with application details', class: 'uk-button uk-button-primary uk-button-large uk-width-large-2-5 uk-float-right'

--- a/app/views/funds/_insights.html.haml
+++ b/app/views/funds/_insights.html.haml
@@ -1,4 +1,4 @@
-%p= raw(fund.description)
+%p= raw(fund.description_html)
 - if fund.period_end.present? && fund.period_end > 3.years.ago
   = period(fund)
 - else

--- a/app/views/funds/_summary_redacted.html.haml
+++ b/app/views/funds/_summary_redacted.html.haml
@@ -46,7 +46,7 @@
         %span.year.muted
           %span.redacted= scramble_name(fund.funder.name)
 
-      %p.redacted.muted= scramble_name(raw(fund.description))
+      %p.redacted.muted= scramble_name(raw(fund.description_html))
 
       %ul.insights
         - unless @proposal.eligible_status(fund.slug).negative?

--- a/app/views/pages/preview.html.haml
+++ b/app/views/pages/preview.html.haml
@@ -20,7 +20,7 @@
                 %span.year.muted
                   %span.redacted Sample funder
 
-            %p= truncate(raw(@fund.description), length: 250, separator: ' ', escape: false)
+            %p= truncate(raw(@fund.description_html), length: 250, separator: ' ', escape: false)
 
             - if @fund.open_data
               = period(@fund)


### PR DESCRIPTION
It's a lot quicker to write markdown when researching funds. Reuses existing markdown implementation from articles.

Should have no problems with existing data as I've allowed any existing html tags to be pulled through unescaped, so all the existing fields should continue to display as expected, 