### PR TITLE
Change to scoped_collection to prevent unauthorized access

### DIFF
--- a/app/admin/article.rb
+++ b/app/admin/article.rb
@@ -3,7 +3,7 @@ ActiveAdmin.register Article do
 
   controller do
     def find_resource
-      Article.find_by(slug: params[:id])
+      scoped_collection.find_by(slug: params[:id])
     end
   end
 

--- a/app/admin/fund.rb
+++ b/app/admin/fund.rb
@@ -22,7 +22,7 @@ ActiveAdmin.register Fund do
 
   controller do
     def find_resource
-      Fund.find_by(slug: params[:id])
+      scoped_collection.find_by(slug: params[:id])
     end
   end
 

--- a/app/admin/funder.rb
+++ b/app/admin/funder.rb
@@ -5,7 +5,7 @@ ActiveAdmin.register Funder do
 
   controller do
     def find_resource
-      Funder.where(slug: params[:id]).first!
+      scoped_collection.where(slug: params[:id]).first!
     end
   end
 

--- a/app/admin/recipient.rb
+++ b/app/admin/recipient.rb
@@ -6,7 +6,7 @@ ActiveAdmin.register Recipient do
 
   controller do
     def find_resource
-      Recipient.where(slug: params[:id]).first!
+      scoped_collection.where(slug: params[:id]).first!
     end
   end
 
@@ -48,9 +48,7 @@ ActiveAdmin.register Recipient do
           row :charity_number
           row :company_number
           row('Users') do |recipient|
-            recipient.users.each do |user|
-              li "#{user.email} | Authorised: #{user.authorised}"
-            end
+            recipient.users.each.map{|user| "<li><a href=\"#{admin_user_path(user)}\">#{user.email}</a> | Authorised: #{user.authorised}</li>"}.join("").html_safe
           end
         end
       end


### PR DESCRIPTION
Apparently for security reasons it's better to use `scoped_collection` in activeadmin. (Branch had been sitting on my machine for a while).